### PR TITLE
[BUGFIX] Add check if generator is valid before traversing it

### DIFF
--- a/Classes/Domain/Site/SiteRepository.php
+++ b/Classes/Domain/Site/SiteRepository.php
@@ -132,6 +132,9 @@ class SiteRepository
         $siteGenerator->rewind();
 
         $sites = [];
+        if (!$siteGenerator->valid()) {
+            return $sites;
+        }        
         foreach ($siteGenerator as $rootPageId => $site) {
             if (isset($sites[$rootPageId])) {
                 //get each site only once


### PR DESCRIPTION
If there's no solr configuration for any site, saving pages or content results in a PHP exception:

Uncaught TYPO3 Exception: Cannot traverse an already closed generator | Exception thrown in file .../Classes/Domain/Site/SiteRepository.php in line 135

The added check prevents this error.
